### PR TITLE
Fix callback spec to the types actually used.

### DIFF
--- a/src/erleans_provider.erl
+++ b/src/erleans_provider.erl
@@ -24,11 +24,11 @@
 
 -callback all(Type :: module(), ProviderName :: atom()) -> {ok, [any()]} | {error, any()}.
 
--callback read(Type :: module(), ProviderName :: atom(), GrainRef :: erleans:grain_ref()) ->
+-callback read(Type :: module(), ProviderName :: atom(), Id :: term()) ->
     {ok, State :: any(), ETag :: erleans:etag()} |
     {error, not_found}.
 
--callback read_by_hash(Type :: module(), ProviderName :: atom(), GrainRef :: erleans:grain_ref()) ->
+-callback read_by_hash(Type :: module(), ProviderName :: atom(), Hash :: integer()) ->
     {ok,  [{GrainRef :: erleans:grain_ref(), Type :: module(), ETag :: erleans:etag(), State :: any()}]} |
     {error, not_found}.
 


### PR DESCRIPTION
The last parameter of read/3 is the ID (see the `ProviderModule:read`
call in `erleans_grain:init` and also the implementation in
erleans_provider_ets).

The last parameter of read_by_hash/3 is the hash value (I don't see it
being called, but the implementation seem to expect integer instead of
the grain_ref).