### PR TITLE
Changes from Leapsight project

### DIFF
--- a/src/erleans_pm.erl
+++ b/src/erleans_pm.erl
@@ -23,6 +23,8 @@
 -export([register_name/2,
          unregister_name/1,
          unregister_name/2,
+         start_guard/1,
+         stop_guard/1,
          whereis_name/1,
          send/2]).
 
@@ -37,30 +39,10 @@
 register_name(Name, Pid) when is_pid(Pid) ->
     case lasp_pg:join(Name, Pid, true) of
         {ok, _} ->
-            %% Set up a callback to be triggered on a single node (lasp handles this)
-            %% when the number of pids registered for this name goes above 1
-            EnforceFun = fun(AwSet) -> deactivate_dups(Name, AwSet) end,
-            lasp:enforce_once({term_to_binary(Name), ?SET}, {strict, {cardinality, 1}}, EnforceFun),
             yes;
         _ ->
             no
     end.
-
-%% deactivate all but a random activation.
-%% It is possible that this will be triggered multiple times and result in no
-%% remaining activations until the next request to a grain.
-deactivate_dups(Name, AwSet) ->
-    Set = state_awset:query(AwSet),
-    Size = sets:size(Set),
-    Keep = rand:uniform(Size),
-    ?LOG_INFO("at=deactivate_dups name=~p size=~p keep=~p", [Name, Size, Keep]),
-    sets:fold(fun(_, N) when N =:= Size ->
-                  N+1;
-                 (Pid, N) ->
-                  supervisor:terminate_child({erleans_grain_sup, node(Pid)}, Pid),
-                  N+1
-              end, 1, Set).
-
 
 -spec unregister_name(Name :: term()) -> Name :: term() | fail.
 unregister_name(Name) ->
@@ -79,6 +61,65 @@ unregister_name(Name, Pid) ->
         _ ->
             fail
     end.
+
+-spec start_guard(Name :: term()) -> {ok, Guard :: pid()} | {error, any()}.
+start_guard(Name) ->
+    %% Set up a callback to be triggered on a single node (lasp handles this)
+    %% when the number of pids registered for this name goes above 1
+    EnforceFun =
+        case erlang:function_exported(twin_service_grain, is_location_right, 1) of
+            true ->
+                fun(AwSet) -> deactivate_dups_twin(Name, AwSet) end;
+            false ->
+                fun(AwSet) -> deactivate_dups(Name, AwSet) end
+        end,
+    lasp:enforce_once({term_to_binary(Name), ?SET}, {strict, {cardinality, 1}}, EnforceFun).
+
+-spec stop_guard(Guard :: pid() | undefined) -> ok | undefined | {error, any()}.
+stop_guard(Guard) when is_pid(Guard) ->
+    supervisor:terminate_child({lasp_process_sup, node(Guard)}, Guard);
+stop_guard(undefined) ->
+    undefined.
+
+deactivate_dups_twin(_Name, AwSet) ->
+    Set = state_awset:query(AwSet),
+    Size = sets:size(Set),
+    sets:fold(
+        fun(Pid, {true, N}) ->
+                terminate_grain(Pid),
+                {true, N+1};
+           (_Pid, {false, N}) when N =:= Size ->
+                {true, N+1};
+           (Pid, {false, N}) ->
+                case twin_service_grain:is_location_right(Pid) of
+                    true ->
+                        {true, N+1};
+                    false ->
+                        terminate_grain(Pid),
+                        {false, N+1};
+                    noproc ->
+                        {false, N+1}
+                end
+        end,
+        {false, 1}, Set).
+
+%% deactivate all but a random activation.
+%% It is possible that this will be triggered multiple times and result in no
+%% remaining activations until the next request to a grain.
+deactivate_dups(Name, AwSet) ->
+    Set = state_awset:query(AwSet),
+    Size = sets:size(Set),
+    Keep = rand:uniform(Size),
+    ?LOG_INFO("at=deactivate_dups name=~p size=~p keep=~p", [Name, Size, Keep]),
+    sets:fold(fun(_, N) when N =:= Size ->
+                  N+1;
+                 (Pid, N) ->
+                  terminate_grain(Pid),
+                  N+1
+              end, 1, Set).
+
+terminate_grain(Pid) ->
+    supervisor:terminate_child({erleans_grain_sup, node(Pid)}, Pid).
 
 -spec whereis_name(GrainRef :: erleans:grain_ref()) -> pid() | undefined.
 whereis_name(GrainRef=#{placement := stateless}) ->

--- a/src/erleans_provider.erl
+++ b/src/erleans_provider.erl
@@ -24,11 +24,11 @@
 
 -callback all(Type :: module(), ProviderName :: atom()) -> {ok, [any()]} | {error, any()}.
 
--callback read(Type :: module(), ProviderName :: atom(), GrainRef :: erleans:grain_ref()) ->
+-callback read(Type :: module(), ProviderName :: atom(), Id :: term()) ->
     {ok, State :: any(), ETag :: erleans:etag()} |
-    {error, not_found}.
+    {error, any()}.
 
--callback read_by_hash(Type :: module(), ProviderName :: atom(), GrainRef :: erleans:grain_ref()) ->
+-callback read_by_hash(Type :: module(), ProviderName :: atom(), Hash :: integer()) ->
     {ok,  [{GrainRef :: erleans:grain_ref(), Type :: module(), ETag :: erleans:etag(), State :: any()}]} |
     {error, not_found}.
 
@@ -41,13 +41,13 @@
                   ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |
-    {error, not_found}.
+    {error, any()}.
 
 -callback update(Type :: module(), ProviderName :: atom(), Id :: any(), Hash :: integer(),
                   State :: any(), ETag :: erleans:etag(), NewETag :: erleans:etag()) ->
     ok |
     {error, {bad_etag, erleans:etag(), erleans:etag()}} |
-    {error, not_found}.
+    {error, any()}.
 
 start_link(Name, #{module := Module,
                    args   := Args}) ->

--- a/src/erleans_sup.erl
+++ b/src/erleans_sup.erl
@@ -51,7 +51,7 @@ init([Config]) ->
                     start => {erleans_grain_sup, start_link, []},
                     restart => permanent,
                     type => supervisor,
-                    shutdown => 5000},
+                    shutdown => infinity},
                   #{id => erleans_discovery,
                     start => {erleans_discovery, start_link, []},
                     restart => permanent,


### PR DESCRIPTION
Includes changes:

- Improved handling of duplicate guard processes to address the issue of leaving processes behind when grain is deactivated.

- Added alternative duplicate handling strategy for twin_service. Erleans asks grain activations and keeps the first that says it is located properly (colocated to its Kafka partition). Since the decision is not random, all guards will come to the same decision so we won't end up in a situation where guards randomly kill all grains of the same reference.

- Fixed some dialyzer warnings.

- Set supervisor's shutdown time to infinity to avoid race conditions explained on erlang.org:

"Setting the shutdown time to anything other than infinity for a child of type supervisor can cause a race condition where the child in question unlinks its own children, but fails to terminate them before it is killed."